### PR TITLE
- bugfix/#24

### DIFF
--- a/config/nibe.php
+++ b/config/nibe.php
@@ -14,5 +14,6 @@
 		'offsetFactor'    => env("NIBE_OFFSET_FACTOR", 2),
 		'offsetMinimum'   => env("NIBE_OFFSET_MINIMUM", -10),
 		'offsetMaximum'   => env("NIBE_OFFSET_MAXIMUM", 10),
+		'offsetMaxInt'    => env("NIBE_OFFSET_MAXIMUM_INTERMITTENT", 0),
 		'tempFreqMin'     => env("NIBE_TEMP_FREQ_MIN", 6),
 	];


### PR DESCRIPTION
	- add 'htgMode' variable to dmOverride to help clarify some logic, and set this to 'on', 'off', or 'intermittent' based on the outside temperature parameters
	- use 'htgMode' to set the DM target and the max heating offset
	- add extra logic if in 'intermittent' mode so that the heating offset and min flow line temp do not continue to climb and prevent the heating cycle from ending