### PR TITLE
enhancement/#51

### DIFF
--- a/app/Console/Commands/TestCommand.php
+++ b/app/Console/Commands/TestCommand.php
@@ -8,6 +8,7 @@
 	use App\Models\ActivityLog;
 	use Carbon\CarbonImmutable;
 	use Illuminate\Console\Command;
+	use Illuminate\Support\Facades\Log;
 
 	class TestCommand extends Command
 	{
@@ -42,9 +43,11 @@
 					'message'    => "Command Start.",
 				]);
 
-				// EmonController::getForecastRoomTemperatureData();
+				$data = EmonController::getLatestEmonData("heatmeter_FlowT", "local", 5);
 				// $syncSuccess = EmonAPI::postInputData("local", CarbonImmutable::now()->startOfMinute()->setTimezone("UTC")->format("U"), "emonth2_23", json_encode(["temperature_forecast" => 21.6]));
-				OctopusController::tryGetAgileRates();
+				// OctopusController::tryGetAgileRates();
+
+				Log::info($data);
 
 
 				ActivityLog::create(

--- a/app/Http/Controllers/HomeAssistantController.php
+++ b/app/Http/Controllers/HomeAssistantController.php
@@ -4,8 +4,10 @@
 	use Exception;
 	use Throwable;
 	use App\APIs\HomeAssistantAPI;
+	use App\Http\Controllers\EmonController;
 	use App\Models\ActivityLog;
 	use App\Models\NibeFeedItem;
+	use App\Models\Setting;
 	use Illuminate\Support\Facades\Log;
 
 	class HomeAssistantController extends Controller
@@ -21,10 +23,70 @@
 					throw new Exception("NibeFeedItem not found");
 				}
 
+				$priority = (int)$latestPriorityNibeFeedItem->rawValue;
+				$setting = Setting::firstWhere(["key" => "htgMode"]);
+				$htgMode = $setting?->value;
+
+				$targetTemp = config("hive.targetOffTemp");
+
+				// if priority is either heating [30] or cooling [60]
+				if ($priority === 30 || $priority === 60)
+				{
+					$targetTemp = config("hive.targetOnTemp");
+
+					ActivityLog::create(
+					[
+						'controller' => __CLASS__,
+						'method'     => __FUNCTION__,
+						'level'      => "info",
+						'message'    => "Priority is '$priority'; targetTemp is ".$targetTemp."degC",
+					]);
+
+					if ($htgMode == "extraBoost")
+					{
+						$targetTemp = config("hive.targetOffTemp");
+
+						ActivityLog::create(
+						[
+							'controller' => __CLASS__,
+							'method'     => __FUNCTION__,
+							'level'      => "info",
+							'message'    => "htgMode is '$htgMode'; targetTemp is ".$targetTemp."degC",
+						]);
+
+						$flowTempRaw = EmonController::getLatestEmonData("heatmeter_FlowT", "local", 5);
+						$flowTemp = (is_null($flowTempRaw) || $flowTempRaw === "") ? 0.0 : (float)$flowTempRaw;
+
+						if ($flowTemp === 0.0)
+						{
+							// Log a warning, but continue safely
+							ActivityLog::create(
+							[
+								'controller' => __CLASS__,
+								'method'     => __FUNCTION__,
+								'level'      => "warning",
+								'message'    => "Flow temperature missing — defaulting to $flowTemp",
+							]);
+						}
+
+						if ($flowTemp > 45)
+						{
+							$targetTemp = config("hive.targetOnTemp");
+
+							ActivityLog::create(
+							[
+								'controller' => __CLASS__,
+								'method'     => __FUNCTION__,
+								'level'      => "info",
+								'message'    => "flowTemp is $flowTemp; targetTemp is ".$targetTemp."degC",
+							]);
+						}
+					}
+				}
+
 				$homeAssistant = new HomeAssistantAPI();
 
-				// if priority is heating [30] or cooling [60]
-				$homeAssistant->adjustHiveThermostat(($latestPriorityNibeFeedItem->rawValue == 30 || $latestPriorityNibeFeedItem->rawValue == 60) ? config("hive.targetOnTemp") : config("hive.targetOffTemp"));
+				$homeAssistant->adjustHiveThermostat($targetTemp);
 			}
 			catch (Throwable $e)
 			{

--- a/app/Http/Controllers/NibeController.php
+++ b/app/Http/Controllers/NibeController.php
@@ -345,6 +345,8 @@
 					'message'    => '$htgMode: '.$htgMode,
 				]);
 
+				$setting = Setting::updateOrCreate(["key" => "htgMode"], ["value" => $htgMode]);
+
 				$dmTarget = static::calculateTargetDm($priority, $htgMode, $outdoorTemp);
 
 				$calculatedFlowTemp = $htgMode == "cooling" ? $calculatedFlowTempCool : $calculatedFlowTempHtg;
@@ -1158,7 +1160,8 @@
 
 			if ($htgMode == "extraBoost")
 			{
-				$dmTarget = config("nibe.dmTarget") + config("nibe.dmTargetBoost"); // room temperature/forecast very low - give it all the beans!
+				// $dmTarget = config("nibe.dmTarget") + config("nibe.dmTargetBoost"); // room temperature/forecast very low - give it all the beans!
+				$dmTarget = config("nibe.dmTargetBoost"); // #51: ^^^ that was too many beans! Stick to dmTargetBoost but now the Hive stat will be off so Grannexe gets all the heat
 
 				ActivityLog::create(
 				[


### PR DESCRIPTION
	- Added new hive control flow: priority -> htgMode -> flowTemp (with >45°C safeguard)
	- Added detailed ActivityLog messages for all decisions
	- Added getLatestEmonData() for retrieving recent non-null Emon values
	- Persist current htgMode via Setting
	- Adjust extraBoost dmTarget to dmTargetBoost only
	- Replace ignore-list with include-list for local feed IDs
	- Minor clean-up in TestCommand
	- closes #51 