### PR TITLE
- enhancement/#69_group-error-messages-on-daily-e-mail

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@ root = true
 
 [*]
 charset = utf-8
-end_of_line = lf
+end_of_line = crlf
 indent_size = 4
 indent_style = tab
 insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-* text=auto eol=lf
+* text=auto eol=crlf
 
 *.blade.php diff=html
 *.css diff=css

--- a/app/Console/Commands/AdministratorEmails.php
+++ b/app/Console/Commands/AdministratorEmails.php
@@ -4,6 +4,7 @@
 	use Throwable;
 	use App\Mail\ActivityLogReport;
 	use App\Models\ActivityLog;
+	use App\Services\ActivityLogSummarizer;
 	use Carbon\Carbon;
 	use Illuminate\Console\Command;
 	use Illuminate\Support\Facades\Mail;
@@ -27,9 +28,10 @@
 		/**
 		 * Execute the console command.
 		 *
+		 * @param ActivityLogSummarizer $activityLogSummarizer
 		 * @return void
 		 */
-		public function handle() : void
+		public function handle(ActivityLogSummarizer $activityLogSummarizer) : void
 		{
 			ActivityLog::create(
 			[
@@ -44,9 +46,10 @@
 			try
 			{
 				$fromDateTime = Carbon::now()->subDays(1);
-				$activityLogs = ActivityLog::where('level', "error")->where('created_at', ">", $fromDateTime->format("Y-m-d H:i:s"))->get();
+				$activityLogs = ActivityLog::where('level', "error")->where('created_at', ">", $fromDateTime->format("Y-m-d H:i:s"))->orderBy('created_at')->get();
+				$activityLogSummary = $activityLogSummarizer->summarize($activityLogs);
 
-				$activityLogReport = new ActivityLogReport("errors", $fromDateTime->format("c"), $activityLogs);
+				$activityLogReport = new ActivityLogReport("errors", $fromDateTime->format("c"), $activityLogSummary, $activityLogs->count());
 				Mail::to(config("app.admin_email"))->send($activityLogReport);
 			}
 			catch (Throwable $e)

--- a/app/Mail/ActivityLogReport.php
+++ b/app/Mail/ActivityLogReport.php
@@ -2,9 +2,9 @@
 	namespace App\Mail;
 
 	use Illuminate\Bus\Queueable;
-	use Illuminate\Database\Eloquent\Collection;
 	use Illuminate\Mail\Mailable;
 	use Illuminate\Queue\SerializesModels;
+	use Illuminate\Support\Collection;
 
 	class ActivityLogReport extends Mailable
 	{
@@ -13,17 +13,20 @@
 		public $data;
 		public $fromDateTimeString;
 		public $logType;
+		public $totalCount;
 
 		/**
 		 * Create a new message instance.
 		 *
-		 * @param $data
+		 * @param Collection<int, array<string, mixed>> $data
+		 * @param int $totalCount Total number of individual logs represented by the summary.
 		 */
-		public function __construct(string $logType, string $fromDateTimeString, Collection $data)
+		public function __construct(string $logType, string $fromDateTimeString, Collection $data, int $totalCount)
 		{
 			$this->logType            = $logType;
 			$this->fromDateTimeString = $fromDateTimeString;
 			$this->data               = $data;
+			$this->totalCount         = $totalCount;
 		}
 
 		/**

--- a/app/Services/ActivityLogSummarizer.php
+++ b/app/Services/ActivityLogSummarizer.php
@@ -1,0 +1,120 @@
+<?php
+	namespace App\Services;
+
+	use DateTimeInterface;
+	use Illuminate\Support\Collection;
+
+	class ActivityLogSummarizer
+	{
+		/**
+		 * Group activity logs into concise error types for the administrator report.
+		 */
+		public function summarize(Collection $activityLogs) : Collection
+		{
+			return $activityLogs->groupBy(fn($log) => $this->groupKey((string) $log->message))->map(function(Collection $logs) : array
+			{
+				$orderedLogs = $logs->sortBy(fn($log) => $this->timestamp($log->created_at));
+				$firstLog    = $orderedLogs->first();
+				$lastLog     = $orderedLogs->last();
+
+				return
+				[
+					'type'       => $this->errorType((string) $firstLog->message),
+					'count'      => $logs->count(),
+					'sources'    => $this->sources($logs),
+					'first_seen' => $this->timestamp($firstLog->created_at),
+					'last_seen'  => $this->timestamp($lastLog->created_at),
+				];
+			})->sortByDesc('count')->values();
+		}
+
+		/**
+		 * Return a stable key so variable details do not split known error types.
+		 */
+		protected function groupKey(string $message) : string
+		{
+			$type = $this->errorType($message);
+
+			if ($type !== $this->normaliseMessage($message))
+			{
+				return strtolower($type);
+			}
+
+			return strtolower($this->normaliseMessage($message));
+		}
+
+		/**
+		 * Categorise known errors. Add more specific rules above the cURL fallback.
+		 */
+		protected function errorType(string $message) : string
+		{
+			if (preg_match('/\bport\s+(\d{1,5})\b/i', $message, $matches) === 1)
+			{
+				return "Port ".$matches[1]." errors";
+			}
+
+			if (stripos($message, "Could not resolve host") !== false)
+			{
+				return "DNS resolution errors";
+			}
+
+			if (stripos($message, "Connection was reset") !== false)
+			{
+				return "Connection reset errors";
+			}
+
+			if (preg_match('/cURL error\s+(\d+):/i', $message, $matches) === 1)
+			{
+				return "cURL error ".$matches[1];
+			}
+
+			return $this->normaliseMessage($message);
+		}
+
+		/**
+		 * Keep unknown errors separate, except for harmless whitespace/case differences.
+		 */
+		protected function normaliseMessage(string $message) : string
+		{
+			$message = trim((string) preg_replace('/\s+/', ' ', $message));
+
+			return $message === "" ? "Uncategorised errors" : $message;
+		}
+
+		/**
+		 * Count the errors produced by each controller and method.
+		 */
+		protected function sources(Collection $logs) : array
+		{
+			return $logs->groupBy(fn($log) => $this->sourceName($log->controller, $log->method))->map(fn(Collection $sourceLogs, string $name) =>
+			[
+				'name'  => $name,
+				'count' => $sourceLogs->count(),
+			])->sortByDesc('count')->values()->all();
+		}
+
+		/**
+		 * Build a compact controller and method label for the report.
+		 */
+		protected function sourceName(?string $controller, ?string $method) : string
+		{
+			$controller = $controller ?: "Unknown controller";
+			$method     = $method ?: "unknown method";
+			$parts      = explode("\\", $controller);
+
+			return end($parts)."::".$method;
+		}
+
+		/**
+		 * Format a log timestamp consistently for display and sorting.
+		 */
+		protected function timestamp($value) : string
+		{
+			if ($value instanceof DateTimeInterface)
+			{
+				return $value->format("Y-m-d H:i:s");
+			}
+
+			return (string) $value;
+		}
+	}

--- a/resources/views/emails/activity_log_report.blade.php
+++ b/resources/views/emails/activity_log_report.blade.php
@@ -1,24 +1,35 @@
 <div>
-    @if (count($data) == 0)
+    @if ($totalCount == 0)
 		<p>Nothing to report</p>
 	@else
-		<p>New log entries since {{$fromDateTimeString}}</p>
-		<table cellspacing="0" cellpadding="5" border="1">
+		<p>
+			<strong>{{number_format($totalCount)}}</strong>
+			new log {{Str::plural('entry', $totalCount)}} since {{$fromDateTimeString}},
+			grouped into <strong>{{number_format(count($data))}}</strong>
+			{{Str::plural('type', count($data))}}.
+		</p>
+		<table cellspacing="0" cellpadding="5" border="1" style="border-collapse: collapse;">
 			<thead>
-				<td>controller</td>
-				<td>method</td>
-				<td>level</td>
-				<td>message</td>
-				<td>created_at</td>
+				<tr>
+					<th align="left">type</th>
+					<th align="right">count</th>
+					<th align="left">sources</th>
+					<th align="left">first seen</th>
+					<th align="left">last seen</th>
+				</tr>
 			</thead>
 			<tbody>
-				@foreach ($data as $log)
+				@foreach ($data as $summary)
 					<tr>
-						<td style="padding: 5px;">{{$log->controller}}</td>
-						<td style="padding: 5px;">{{$log->method}}</td>
-						<td style="padding: 5px;">{{$log->level}}</td>
-						<td style="padding: 5px;">{{$log->message}}</td>
-						<td style="padding: 5px;">{{$log->created_at}}</td>
+						<td style="padding: 5px;">{{$summary['type']}}</td>
+						<td align="right" style="padding: 5px;">{{number_format($summary['count'])}}</td>
+						<td style="padding: 5px;">
+							@foreach ($summary['sources'] as $source)
+								{{$source['name']}} ({{number_format($source['count'])}})@unless($loop->last)<br>@endunless
+							@endforeach
+						</td>
+						<td style="padding: 5px;">{{$summary['first_seen']}}</td>
+						<td style="padding: 5px;">{{$summary['last_seen']}}</td>
 					</tr>
 				@endforeach
 			</tbody>

--- a/tests/Feature/ActivityLogReportTest.php
+++ b/tests/Feature/ActivityLogReportTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Mail\ActivityLogReport;
+use Tests\TestCase;
+
+class ActivityLogReportTest extends TestCase
+{
+    /**
+     * Verify the email displays grouped counts instead of individual log rows.
+     */
+    public function test_the_report_renders_group_counts_instead_of_individual_logs(): void
+    {
+        $report = new ActivityLogReport(
+            "errors",
+            "2026-07-16T06:00:00+01:00",
+            collect([
+                [
+                    'type' => "Port 443 errors",
+                    'count' => 159,
+                    'sources' => [
+                        ['name' => "NibeController::syncNibeData", 'count' => 159],
+                    ],
+                    'first_seen' => "2026-07-17 00:06:23",
+                    'last_seen' => "2026-07-17 18:25:56",
+                ],
+                [
+                    'type' => "DNS resolution errors",
+                    'count' => 2,
+                    'sources' => [
+                        ['name' => "EmonController::getEmonFeeds", 'count' => 2],
+                    ],
+                    'first_seen' => "2026-07-17 01:00:00",
+                    'last_seen' => "2026-07-17 02:00:00",
+                ],
+            ]),
+            161
+        );
+
+        $html = $report->render();
+
+        $this->assertStringContainsString("161", $html);
+        $this->assertStringContainsString("grouped into <strong>2</strong>", $html);
+        $this->assertStringContainsString("Port 443 errors", $html);
+        $this->assertStringContainsString("NibeController::syncNibeData (159)", $html);
+    }
+
+    /**
+     * Verify the email retains its empty-period message.
+     */
+    public function test_the_report_handles_an_empty_period(): void
+    {
+        $html = (new ActivityLogReport(
+            "errors",
+            "2026-07-16T06:00:00+01:00",
+            collect(),
+            0
+        ))->render();
+
+        $this->assertStringContainsString("Nothing to report", $html);
+    }
+}

--- a/tests/Unit/ActivityLogSummarizerTest.php
+++ b/tests/Unit/ActivityLogSummarizerTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\ActivityLogSummarizer;
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class ActivityLogSummarizerTest extends TestCase
+{
+    /**
+     * Verify variable timeout durations are grouped into one port category.
+     */
+    public function test_it_groups_variable_port_errors_and_sorts_by_count(): void
+    {
+        $logs = new Collection([
+            $this->log(
+                "cURL error 28: Failed to connect to emoncms.org port 443 after 21161 ms: Timed out",
+                "2026-07-17 00:06:23",
+                "App\\Http\\Controllers\\NibeController",
+                "syncNibeData"
+            ),
+            $this->log(
+                "cURL error 28: Failed to connect to emoncms.org port 443 after 21625 ms: Timed out",
+                "2026-07-17 00:07:08",
+                "App\\Http\\Controllers\\NibeController",
+                "syncNibeData"
+            ),
+            $this->log(
+                "cURL error 6: Could not resolve host: emoncms.org",
+                "2026-07-17 00:08:00",
+                "App\\Http\\Controllers\\EmonController",
+                "getEmonFeeds"
+            ),
+        ]);
+
+        $summary = (new ActivityLogSummarizer())->summarize($logs);
+
+        $this->assertCount(2, $summary);
+        $this->assertSame("Port 443 errors", $summary[0]['type']);
+        $this->assertSame(2, $summary[0]['count']);
+        $this->assertSame("2026-07-17 00:06:23", $summary[0]['first_seen']);
+        $this->assertSame("2026-07-17 00:07:08", $summary[0]['last_seen']);
+        $this->assertSame(
+            [['name' => "NibeController::syncNibeData", 'count' => 2]],
+            $summary[0]['sources']
+        );
+        $this->assertSame("DNS resolution errors", $summary[1]['type']);
+    }
+
+    /**
+     * Verify known patterns are categorised while unknown messages remain distinct.
+     */
+    public function test_it_groups_known_errors_and_uses_exact_message_as_the_fallback(): void
+    {
+        $logs = new Collection([
+            $this->log("cURL error 56: OpenSSL SSL_read: Connection was reset, errno 10054"),
+            $this->log("cURL error 56: OpenSSL SSL_read: Connection was reset, errno 10054"),
+            $this->log("App\\APIs\\NibeAPI::getParameterData(): Return value must be of type array, null returned"),
+            $this->log("  app\\apis\\nibeapi::getparameterdata():   return value must be of type array, null returned  "),
+            $this->log("A different application error"),
+        ]);
+
+        $summary = (new ActivityLogSummarizer())->summarize($logs);
+
+        $this->assertCount(3, $summary);
+        $this->assertSame("Connection reset errors", $summary[0]['type']);
+        $this->assertSame(2, $summary[0]['count']);
+        $this->assertSame(
+            "App\\APIs\\NibeAPI::getParameterData(): Return value must be of type array, null returned",
+            $summary[1]['type']
+        );
+        $this->assertSame(2, $summary[1]['count']);
+        $this->assertSame("A different application error", $summary[2]['type']);
+        $this->assertSame(1, $summary[2]['count']);
+    }
+
+    /**
+     * Verify incomplete logs still produce a useful summary category and source.
+     */
+    public function test_it_handles_empty_messages_and_missing_source_details(): void
+    {
+        $summary = (new ActivityLogSummarizer())->summarize(new Collection([
+            $this->log("", "2026-07-17 00:00:00", null, null),
+            $this->log("   ", "2026-07-17 00:01:00", null, null),
+        ]));
+
+        $this->assertCount(1, $summary);
+        $this->assertSame("Uncategorised errors", $summary[0]['type']);
+        $this->assertSame(2, $summary[0]['count']);
+        $this->assertSame(
+            [['name' => "Unknown controller::unknown method", 'count' => 2]],
+            $summary[0]['sources']
+        );
+    }
+
+    /**
+     * Create a lightweight activity log object for summarizer tests.
+     */
+    private function log(
+        string $message,
+        string $createdAt = "2026-07-17 00:00:00",
+        ?string $controller = "App\\Http\\Controllers\\NibeController",
+        ?string $method = "syncNibeData"
+    ): stdClass {
+        return (object) [
+            'message' => $message,
+            'created_at' => $createdAt,
+            'controller' => $controller,
+            'method' => $method,
+        ];
+    }
+}


### PR DESCRIPTION
	- add ActivityLogSummarizer with summarize() method to group error messages in the ActivityLogReport
	- update line endings to CRLF